### PR TITLE
fix: readme markdown table

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,18 +67,13 @@ The reports can be found in the location `build/reports/` relative to the corres
 
 ### Test execution
 
-|                          **Command** | **
-Task**                                                                                         |
-|-------------------------------------:|:
--------------------------------------------------------------------------------------------------|
-|                        `gradle test` | Run **
-all** unit tests |
-|            `gradle: subproject:test` | Run unit test from **
-specific** subproject <br/> (i.g. `gradle :runtime:test`)                   |
-|             `gradle integrationTest` | Run **
-all** Integration test |
-| `gradle :subproject:integrationTest` | Run integration test from **
-specific** subproject <br/> (i.g. `gradle: runtime:integrationTest`) |
+
+| **Command**                          | **Task**                                                                                          |
+|------------------------------------- | ------------------------------------------------------------------------------------------------- |
+|                        `gradle test` | Run ** all** unit tests |
+|            `gradle: subproject:test` | Run unit test from ** specific** subproject <br/> (i.g. `gradle :runtime:test`)                   |
+|             `gradle integrationTest` | Run ** all** Integration test |
+| `gradle :subproject:integrationTest` | Run integration test from ** specific** subproject <br/> (i.g. `gradle: runtime:integrationTest`) |
 
 ## Monitor
 


### PR DESCRIPTION
fixes only the markdown table in the `README.md`, which is sensitive with line-breaks